### PR TITLE
Using the default GOROOT if not set

### DIFF
--- a/snippets
+++ b/snippets
@@ -746,10 +746,13 @@ endfunction
 " Clear filetype flags before changing runtimepath to force Vim to reload them.
 filetype off
 filetype plugin indent off
-set runtimepath+=$GOROOT/misc/vim
+if empty($GOROOT)
+  set runtimepath+=/usr/local/go/misc/vim
+else
+  set runtimepath+=$GOROOT/misc/vim
+endif
 filetype plugin indent on
 syntax on
-
 if executable('go')
   autocmd FileType go autocmd BufWritePre <buffer> Fmt
   " Activate the compiler plugin with ":compiler go". To always enable the


### PR DESCRIPTION
Hi Luca, 

It seems that setting `$GOROOT` is only recommended if you have installed `go` to a non-standard location, ie. not in `/usr/local/go`

http://dave.cheney.net/2013/06/14/you-dont-need-to-set-goroot-really

There might be a nicer way of writing the below but it sorted out the syntax highlighting for me :)