### PR TITLE
Add support for typescript and elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ These are only installed when running the full install: `./install/full`
 * [vim-go](https://github.com/fatih/vim-go) - Full featured Go development environment. This plugin will create the executable it needs, if the golang runtime is available, the first time Vim is run. This might take a couple of minutes.
 * [vim-ruby-xmpfilter](https://github.com/t9md/vim-ruby-xmpfilter) - Helper for ruby's xmpfilter or seeing_is_believing. Evaluates Ruby code inline and print the result as a comment at the end of the line.
 * [Vimux](https://github.com/benmills/vimux) - Easily interact with tmux from Vim.
+* [typescript-vim](https://github.com/leafgarland/typescript-vim) - Typescript syntax files for Vim.
+* [elixir-lang/vim-elixir](https://github.com/elixir-lang/vim-elixir) - Vim configuration files for Elixir.
 
 Colorschemes:
 

--- a/install/config.sh
+++ b/install/config.sh
@@ -52,4 +52,6 @@ declare -a -r NICE_TO_HAVES=(
   "tomasr/molokai"
   "tpope/vim-rails"
   "vim-ruby/vim-ruby"
+  "leafgarland/typescript-vim"
+  "elixir-lang/vim-elixir"
 )

--- a/plugin/whitespace.vim
+++ b/plugin/whitespace.vim
@@ -38,6 +38,6 @@ function! <SID>StripTrailingWhitespaces()
   call cursor(l, c)
 endfun
 
-autocmd FileType Dockerfile,make,c,coffee,cpp,css,eruby,html,java,javascript,json,markdown,php,puppet,python,ruby,scss,sh,sql,text,vim,yaml autocmd BufWritePre <buffer> :call <SID>StripTrailingWhitespaces()
+autocmd FileType Dockerfile,make,c,coffee,cpp,css,eruby,eelixir,elixir,html,java,javascript,json,markdown,php,puppet,python,ruby,scss,sh,sql,text,typescript,vim,yaml autocmd BufWritePre <buffer> :call <SID>StripTrailingWhitespaces()
 " Conflicts with the same functionality provided by gofmt + fatih/vim-go
 " autocmd FileType go           autocmd BufWritePre <buffer> :call <SID>StripTrailingWhitespaces()


### PR DESCRIPTION
Summary:
* Adds `typescript-vim` and `vim-elixir` to the "nice to have" lot of vim plugins.
* Incorporates corresponding file types in whitespace module.